### PR TITLE
fix path of installer.sh in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \ 
     apt-get -y upgrade && \
-    apt-get -y install wget kmod procps sudo
+    apt-get -y install wget kmod procps sudo && \
+    sudo apt-get install -y apt-utils && \
+    sudo apt-get install -y default-libmysqlclient-dev && \
+    sudo apt-get install -y mysql-client && \
+    sudo apt-get install -y python3-mysqldb && \
+    sudo apt-get install -y build-essential && \
+    sudo apt-get install -y python3-dev && \
+    sudo apt-get install -y libssl-dev && \
+    sudo apt-get install -y swig
 
 
 ADD . /app
 
 WORKDIR /app/embark
+
 
 ADD embark/requirements.txt /app/embark/requirements.txt
 
@@ -18,16 +27,6 @@ RUN yes | sudo /app/emba/installer.sh -D -F  && \
     pip3 install --user --no-warn-script-location -r /app/embark/requirements.txt && \
     mkdir /app/embark/logs
 
-
-RUN sudo apt-get update && \
-    sudo apt-get install -y apt-utils && \
-    sudo apt-get install -y default-libmysqlclient-dev && \
-    sudo apt-get install -y mysql-client && \
-    sudo apt-get install -y python-mysqldb && \
-    sudo apt-get install -y build-essential && \
-    sudo apt-get install -y python3-dev && \
-    sudo apt-get install -y libssl-dev && \
-    sudo apt-get install -y swig
 
 EXPOSE 8000
 # Opening on extra port for our ASGI setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app/embark
 
 ADD embark/requirements.txt /app/embark/requirements.txt
 
-RUN yes | sudo ./emba/installer.sh -D -F  && \
+RUN yes | sudo /app/emba/installer.sh -D -F  && \
     sudo pip3 install uwsgi -I --no-cache-dir && \
     pip3 install --user --no-warn-script-location -r /app/embark/requirements.txt && \
     mkdir /app/embark/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get -y install wget kmod procps sudo && \
     sudo apt-get install -y apt-utils && \
     sudo apt-get install -y default-libmysqlclient-dev && \
-    sudo apt-get install -y mysql-client && \
-    sudo apt-get install -y python3-mysqldb && \
+    sudo apt-get install -y default-mysql-client && \
     sudo apt-get install -y build-essential && \
     sudo apt-get install -y python3-dev && \
     sudo apt-get install -y libssl-dev && \


### PR DESCRIPTION
- Path of installer.sh as absolute path
- Currently tries to take relative path - Bug
- Missed during previous commits
- Few other fixes in dockerfile specific to debian linux